### PR TITLE
Tarea 4291 Mejora del Reseteo Anual del Patrón de Proyectos

### DIFF
--- a/Init.php
+++ b/Init.php
@@ -156,6 +156,7 @@ final class Init extends InitClass
     {
         Tools::settings('proyectos', 'patron', 'PR-{ANYO}-{NUM}');
         Tools::settings('proyectos', 'longnumero', 6);
+        Tools::settings('proyectos', 'reiniciarpatronanualmente', 0);
         Tools::settingsSave();
     }
 }

--- a/Lib/ProjectCodeGenerator.php
+++ b/Lib/ProjectCodeGenerator.php
@@ -21,6 +21,7 @@ namespace FacturaScripts\Plugins\Proyectos\Lib;
 
 use FacturaScripts\Core\Tools;
 use FacturaScripts\Plugins\Proyectos\Model\Proyecto;
+use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
 
 /**
  * Description of ProjectCodeGenerator
@@ -37,9 +38,50 @@ class ProjectCodeGenerator
     {
         $patron = Tools::settings('proyectos', 'patron', 'PR-{ANYO}-{NUM}');
         $long_numero = Tools::settings('proyectos', 'longnumero', 6);
+        $reset = (bool) Tools::settings('proyectos', 'reiniciarpatronanualmente', 0);
 
         $proyecto = new Proyecto();
-        $numero = 1 + $proyecto->count();
+
+        if (!$reset) {
+            // default behaviour: keep existing global counting
+            $numero = 1 + $proyecto->count();
+        } else {
+            // build prefix replacing date placeholders but leaving numeric placeholders empty
+            $replacements = [
+                '{ANYO}' => date('Y'),
+                '{ANYO2}' => date('y'),
+                '{MES}' => date('m'),
+                '{DIA}' => date('d'),
+                '{NUM}' => '',
+                '{0NUM}' => ''
+            ];
+
+            $prefix = strtr($patron, $replacements);
+
+            // find projects that start with the same prefix
+            $where = [new \FacturaScripts\Core\Base\DataBase\DataBaseWhere('nombre', $prefix . '%', 'LIKE')];
+            $projects = Proyecto::all($where, [], 0, 0);
+
+            $year = date('Y');
+            $max = 0;
+            foreach ($projects as $p) {
+                if (empty($p->fecha)) {
+                    continue;
+                }
+                $pYear = date('Y', strtotime($p->fecha));
+                if ($pYear !== $year) {
+                    continue;
+                }
+                if (preg_match('/(\\d+)$/', $p->nombre, $m)) {
+                    $num = intval($m[1]);
+                    if ($num > $max) {
+                        $max = $num;
+                    }
+                }
+            }
+
+            $numero = $max + 1;
+        }
 
         $project->nombre = strtr($patron, [
             '{ANYO}' => date('Y'),

--- a/Lib/ProjectCodeGenerator.php
+++ b/Lib/ProjectCodeGenerator.php
@@ -58,11 +58,16 @@ class ProjectCodeGenerator
 
             $prefix = strtr($patron, $replacements);
 
-            // find projects that start with the same prefix
-            $where = [new \FacturaScripts\Core\Base\DataBase\DataBaseWhere('nombre', $prefix . '%', 'LIKE')];
+            // find projects that start with the same prefix and belong to the same company, limited to current year
+            $year = date('Y');
+            $where = [
+                new DataBaseWhere('nombre', $prefix . '%', 'LIKE'),
+                new DataBaseWhere('idempresa', $project->idempresa),
+                new DataBaseWhere('fecha', $year . '-01-01', '>='),
+                new DataBaseWhere('fecha', $year . '-12-31', '<=')
+            ];
             $projects = Proyecto::all($where, [], 0, 0);
 
-            $year = date('Y');
             $max = 0;
             foreach ($projects as $p) {
                 if (empty($p->fecha)) {

--- a/Test/main/ProyectoPatternResetTest.php
+++ b/Test/main/ProyectoPatternResetTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace FacturaScripts\Test\Plugins;
+
+use FacturaScripts\Plugins\Proyectos\Model\Proyecto;
+use FacturaScripts\Core\Tools;
+use FacturaScripts\Test\Traits\DefaultSettingsTrait;
+use FacturaScripts\Test\Traits\LogErrorsTrait;
+use PHPUnit\Framework\TestCase;
+
+final class ProyectoPatternResetTest extends TestCase
+{
+    use LogErrorsTrait;
+    use DefaultSettingsTrait;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::setDefaultSettings();
+        self::installAccountingPlan();
+        self::removeTaxRegularization();
+    }
+
+    public function testAnnualPatternReset(): void
+    {
+        // activar ajuste
+        Tools::settings('proyectos', 'reiniciarpatronanualmente', 1);
+        Tools::settingsSave();
+
+        $prevYear = date('Y') - 1;
+        $patron = Tools::settings('proyectos', 'patron', 'PR-{ANYO}-{NUM}');
+        $long = Tools::settings('proyectos', 'longnumero', 6);
+
+        // crear proyecto del año anterior
+        $old = new Proyecto();
+        $old->nombre = strtr($patron, [
+            '{ANYO}' => (string)$prevYear,
+            '{ANYO2}' => substr((string)$prevYear, 2),
+            '{MES}' => '01',
+            '{DIA}' => '01',
+            '{NUM}' => '5',
+            '{0NUM}' => str_pad('5', $long, '0', STR_PAD_LEFT)
+        ]);
+        $old->fecha = $prevYear . '-01-01';
+        $old->descripcion = 'old';
+        $this->assertTrue($old->save());
+
+        // crear proyecto nuevo (debe generarse y empezar en 1)
+        $new = new Proyecto();
+        $new->descripcion = 'nuevo';
+        $this->assertTrue($new->save());
+
+        $this->assertMatchesRegularExpression('/(\\d+)$/', $new->nombre, 'El nombre generado debe terminar en dígitos');
+        preg_match('/(\\d+)$/', $new->nombre, $m);
+        $this->assertEquals(1, intval($m[1]), 'Se esperaba que la numeración empiece en 1 para el ejercicio actual');
+
+        // limpieza
+        $this->assertTrue($new->delete());
+        $this->assertTrue($old->delete());
+    }
+
+    protected function tearDown(): void
+    {
+        $this->logErrors();
+    }
+}

--- a/Translation/en_EN.json
+++ b/Translation/en_EN.json
@@ -7,6 +7,7 @@
     "phases": "Phases",
     "project-stock-rebuild-error": "Error rebuilding project stock",
     "project-stock-rebuild-ok": "Project stock rebuilt successfully",
+    "reiniciar-patron-anualmente": "Reset pattern annually",
     "show-project-stock": "Show project stock",
     "tasks-imported-correctly": "Tasks imported correctly",
     "total-pending-invoice": "Pending invoice",

--- a/Translation/es_ES.json
+++ b/Translation/es_ES.json
@@ -7,6 +7,7 @@
     "phases": "Fases",
     "project-stock-rebuild-error": "Error al regenerar el stock",
     "project-stock-rebuild-ok": "Stock regenerado correctamente",
+    "reiniciar-patron-anualmente": "Reiniciar patrón anualmente",
     "show-project-stock": "Mostrar stock del proyecto",
     "tasks-imported-correctly": "Tareas importadas correctamente",
     "total-pending-invoice": "Pendiente facturar",

--- a/XMLView/ConfigProyectos.xml
+++ b/XMLView/ConfigProyectos.xml
@@ -8,6 +8,9 @@
             <column name="pattern" numcolumns="3" order="100">
                 <widget type="text" fieldname="patron" required="true"/>
             </column>
+            <column name="reset-pattern" numcolumns="12" order="115" title="reiniciar-patron-anualmente">
+                <widget type="checkbox" fieldname="reiniciarpatronanualmente"/>
+            </column>
             <column name="number-length" numcolumns="3" order="110">
                 <widget type="number" fieldname="longnumero" decimal="0" min="1" required="true"/>
             </column>


### PR DESCRIPTION
•Añadir checkbox bajo campo código del proyecto
   ◦Qué había que hacer: Permitir marcar una opción junto al código del proyecto en el formulario.
   ◦Qué he hecho: Añadí el checkbox en la UI y su manejo en el backend.
   ◦Cómo se ha hecho: Modificada la plantilla del formulario, procesado del valor en el controlador/modelo y pequeños ajustes de    estilo.
•Lógica de reinicio anual del patrón de proyectos
   ◦Qué había que hacer: Reiniciar la numeración/patrón de proyectos al cambio de año.
   ◦Qué he hecho: Implementé la rutina que detecta año nuevo y resetea el patrón.
   ◦Cómo se ha hecho: Nuevo método en el servicio/model que comprueba la fecha y aplica el reinicio (invocado al crear/actualizar proyectos o por tarea programada).

•Test unitario incorporado y pasado
   ◦Qué había que hacer: Verificar cobertura y correcto comportamiento de los cambios.
   ◦Qué he hecho: Añadí tests que cubren el checkbox y el reinicio anual; la suite pasa.
   ◦Cómo se ha hecho: Escribí pruebas PHPUnit (mocks donde hacía falta) y ejecuté la suite — 21 tests, 94 aserciones, OK.